### PR TITLE
Securitytxt - use builtin search distance

### DIFF
--- a/bbot/modules/securitytxt.py
+++ b/bbot/modules/securitytxt.py
@@ -65,18 +65,15 @@ class securitytxt(BaseModule):
         "created_date": "2024-05-26",
     }
     options = {
-        "in_scope_only": True,
         "emails": True,
         "urls": True,
     }
     options_desc = {
-        "in_scope_only": "Only emit events related to in-scope domains",
         "emails": "emit EMAIL_ADDRESS events",
         "urls": "emit URL_UNVERIFIED events",
     }
 
     async def setup(self):
-        self.in_scope_only = self.config.get("in_scope_only", True)
         self._emails = self.config.get("emails", True)
         self._urls = self.config.get("urls", True)
         return await super().setup()
@@ -89,11 +86,6 @@ class securitytxt(BaseModule):
     async def filter_event(self, event):
         if "_wildcard" in str(event.host).split("."):
             return False, "event is wildcard"
-
-        # scope filtering
-        if event.scope_distance > 0 and self.in_scope_only:
-            return False, "event is not in scope"
-
         return True
 
     async def handle_event(self, event):

--- a/bbot/test/test_step_2/module_tests/test_module_securitytxt.py
+++ b/bbot/test/test_step_2/module_tests/test_module_securitytxt.py
@@ -31,16 +31,14 @@ class TestSecurityTxt(ModuleTestBase):
         assert not any(str(e.data) == "vdp@example.com" for e in events)
 
 
-class TestSecurityTxtInScopeFalse(TestSecurityTxt):
+class TestSecurityTxtEmailsFalse(TestSecurityTxt):
     config_overrides = {
         "scope": {"report_distance": 1},
-        "modules": {"securitytxt": {"in_scope_only": False}},
+        "modules": {"securitytxt": {"emails": False}},
     }
 
     def check(self, module_test, events):
-        assert any(
-            e.type == "EMAIL_ADDRESS" and e.data == "vdp@example.com" for e in events
-        ), "Failed to detect email address"
+        assert not any(e.type == "EMAIL_ADDRESS" for e in events), "Detected email address when emails=False"
         assert any(
             e.type == "URL_UNVERIFIED" and e.data == "https://vdp.example.com/" for e in events
         ), "Failed to detect URL"


### PR DESCRIPTION
This removes the `in_scope_only` option, which wasn't having any effect except when the scan's `scope.search_distance` was increased.

The module is in-scope-only by default, but will scale with the search distance of the scan:

```bash
bbot -t evilcorp.com -m securitytxt -c scope.search_distance=1
```

https://github.com/blacklanternsecurity/bbot/pull/1628